### PR TITLE
Bump pyo3 to 0.29, enable Python 3.14 and PyPy 3.11 wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.11']
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ethereum/blake2b-py"
 description = "Blake2b hashing in Rust with Python bindings."
 
 [dependencies]
-pyo3 = { version = "~0.23", features = ["extension-module"] }
+pyo3 = { version = "~0.29", features = ["extension-module"] }
 
 [dev-dependencies]
 hex = "~0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,14 +103,14 @@ fn checked_compress(
 /// out : bytes
 ///     A vector of 64 bytes representing the blake2b hash of the input data.
 #[pyfunction]
-fn compress(
-    py: Python,
+fn compress<'py>(
+    py: Python<'py>,
     rounds: usize,
     starting_state: Vec<u64>,
     block: Vec<u64>,
     offset_counters: Vec<u64>,
     final_block_flag: bool,
-) -> PyResult<PyObject> {
+) -> PyResult<Bound<'py, PyBytes>> {
     let result = checked_compress(
         rounds,
         &starting_state,
@@ -121,7 +121,7 @@ fn compress(
 
     match result {
         Err(msg) => Err(PyValueError::new_err(msg)),
-        Ok(ok) => Ok(PyBytes::new(py, &ok).into()),
+        Ok(ok) => Ok(PyBytes::new(py, &ok)),
     }
 }
 
@@ -146,12 +146,12 @@ fn _decode_and_compress(input: Vec<u8>) -> Result<[u8; 64], String> {
 /// out : bytes
 ///     A vector of 64 bytes representing the blake2b hash of the input data.
 #[pyfunction]
-fn decode_and_compress(py: Python, input: Vec<u8>) -> PyResult<PyObject> {
+fn decode_and_compress<'py>(py: Python<'py>, input: Vec<u8>) -> PyResult<Bound<'py, PyBytes>> {
     let result = _decode_and_compress(input);
 
     match result {
         Err(msg) => Err(PyValueError::new_err(msg)),
-        Ok(ok) => Ok(PyBytes::new(py, &ok).into()),
+        Ok(ok) => Ok(PyBytes::new(py, &ok)),
     }
 }
 


### PR DESCRIPTION
### What was wrong?

Closes #6

`blake2b-py` cannot be installed on CPython 3.14 or PyPy 3.11: no wheels are published for them, and source builds fail even with a Rust toolchain because the pinned `pyo3 ~0.23` refuses to compile against anything newer than CPython 3.13 or PyPy 3.10:

```console
error: the configured PyPy interpreter version (3.11) is newer than PyO3's maximum supported version (3.10)
```

This blocks downstream consumers that already run on CPython 3.14 (e.g. [ethereum/execution-specs](https://github.com/ethereum/execution-specs) CI, see [PR #3115](https://github.com/ethereum/execution-specs/pull/3115#pullrequestreview-4703639194)).

### How was it fixed?

- Bump `pyo3` from `~0.23` to `~0.29`: This supports CPython 3.8-3.15 and PyPy 3.11+, so the existing 3.8-3.13 wheel matrix keeps working while 3.14 (and, at the next bump, 3.15) becomes buildable.
- Migrate off the removed `PyObject` alias: `compress` and `decode_and_compress` now return `Bound<'py, PyBytes>` directly, which is the idiomatic pyo3 0.29 signature and drops the explicit `.into()` conversion. No behavior change.
- Add Python 3.14 and PyPy 3.11 to the CI `test` and `build` matrices so cp314 and pp311 wheels are tested and published with the next release. Publishing PyPy wheels resolves #6 for PyPy 3.11+ (pyo3 0.29 does not support older PyPy versions).

Verified the build locally of the release wheels with maturin for CPython 3.8, 3.13, 3.14, and PyPy 3.11; the hypothesis equivalence suite in `tests/` passes on all four, and `blake2b.test()` (EIP-152 vectors) passes on 3.14.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes

#### Cute Animal Picture

<!-- Drag and drop tmp/cp314-ready-cat.jpg here when opening the PR; GitHub uploads it as a static user-attachments image. -->
